### PR TITLE
GCR Nested Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If the `target` registry does _not_ support nested paths, only the base path of 
 mycompany.com/myteam/prometheus-operator:v0.40.0
 ```
 
-**Registries that do not support nested paths:** Docker Hub, Google Container Registry (GCR), Quay.io
+**Registries that do not support nested paths:** Docker Hub, Quay.io
 
 ## Usage
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -362,11 +362,6 @@ func getEncodedBasicAuth(username string, password string) (string, error) {
 
 func hostSupportsNestedRepositories(host string) bool {
 
-	// Google Container Registry (GCR)
-	if strings.Contains(host, "gcr.io") {
-		return false
-	}
-
 	// Quay.io
 	if strings.Contains(host, "quay.io") {
 		return false


### PR DESCRIPTION
Unlike quay.io, docker hub, GCR registries support nested paths nested paths in image names. This change will let sinker generate nested paths for images in GCR repositories.