### PR TITLE
[#35] Improve ImageExists check

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -188,6 +188,9 @@ func (c Client) ImageExistsAtRemote(ctx context.Context, image string) (bool, er
 				if strings.EqualFold("MANIFEST_UNKNOWN", string(diagnostic.Code)) {
 					return false, nil
 				}
+				if strings.EqualFold("NOT_FOUND", string(diagnostic.Code)) {
+					return false, nil
+				}
 			}
 		}
 


### PR DESCRIPTION
When checking if a registry has an image manifest, most registries
return MANIFEST_UNKNOWN. Harbor registry however replies with
NOT_FOUND which is according to OCI the valid answer.
This change allows both these answers. Fixes Issue #35 