### PR TITLE
pull.go: log on stderr instead of returning error on a per image basis

### DIFF
--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -80,7 +80,7 @@ func runPullCommand(origin string, manifestPath string) error {
 	for image, auth := range imagesToPull {
 		log.Infof("Pulling %s", image)
 		if err := client.PullImageAndWait(ctx, image, auth); err != nil {
-			return fmt.Errorf("pull image and wait: %w", err)
+			log.Errorf("pull image and wait: " + err.Error())
 		}
 	}
 


### PR DESCRIPTION
This PR makes the pull image loop less sensitive to registry connection error - basically returns a message on stderr but does not exit sinker when the pull operation on one image is failing, which is more adapted for CI usage. Example:
``` 
INFO[0025] Pulling docker.elastic.co/kibana/kibana-oss:7.4.2-SNAPSHOT 
INFO[0026] Unable to pull docker.elastic.co/kibana/kibana-oss:7.4.2-SNAPSHOT (Retrying #1) 
INFO[0032] Unable to pull docker.elastic.co/kibana/kibana-oss:7.4.2-SNAPSHOT (Retrying #2) 
ERRO[0032] pull image and wait: retry: All attempts fail:
#1: try pull image: pull image: Error response from daemon: Get https://docker.elastic.co/v2/kibana/kibana-oss/manifests/7.4.2-SNAPSHOT: unauthorized: authentication required
#2: try pull image: pull image: Error response from daemon: Get https://docker.elastic.co/v2/kibana/kibana-oss/manifests/7.4.2-SNAPSHOT: unauthorized: authentication required 
INFO[0032] All images have been pulled!  
```