### PR TITLE
Resolve bug in mis-identified image detection

### DIFF
--- a/internal/manifest/kubernetes.go
+++ b/internal/manifest/kubernetes.go
@@ -241,7 +241,7 @@ func getImagesFromContainers(containers []corev1.Container) []string {
 			}
 
 			//Work-around for mis-identified image
-			if strings.Contains(image, "http://") {
+			if strings.Contains(image, "http://") || strings.Contains(image, "https://") {
 				continue
 			}
 

--- a/internal/manifest/kubernetes.go
+++ b/internal/manifest/kubernetes.go
@@ -240,6 +240,11 @@ func getImagesFromContainers(containers []corev1.Container) []string {
 				continue
 			}
 
+			//Work-around for mis-identified image
+			if strings.Contains(image, "http://") {
+				continue
+			}
+
 			registryPath := docker.RegistryPath(image)
 			if registryPath.Repository() == "" {
 				continue

--- a/internal/manifest/kubernetes_test.go
+++ b/internal/manifest/kubernetes_test.go
@@ -28,3 +28,29 @@ func TestGetImagesFromContainers_WithEqualSign(t *testing.T) {
 		t.Errorf("expected newlineimage:v1 to exist in list of images but it did not: %v", actual)
 	}
 }
+
+func TestGetImagesFromContainers_WithURLParameter(t *testing.T) {
+	containers := []corev1.Container{
+		{
+			Image: "baseimage:v1",
+			Args: []string{
+				"--events-addr=http://service/",
+				"--events-addr=https://service/",
+			},
+		},
+	}
+	actual := getImagesFromContainers(containers)
+
+	if !contains(actual, "baseimage:v1") {
+		t.Errorf("expected baseimage:v1 to exist in list of images but it did not: %v", actual)
+	}
+
+	if contains(actual, "http://service/") {
+		t.Errorf("Invalid image parsing for args contain http addresses: %v", actual)
+	}
+
+	if contains(actual, "https://service/") {
+		t.Errorf("Invalid image parsing for args contain https addresses: %v", actual)
+	}
+
+}


### PR DESCRIPTION
In a recent kubernetes manifest, noticed it was mis-parsing container arguments and adding an inappropriate image.  This is a temporary workaround, although a more graceful solution may involve rearchitecting the parsing code in [getImagesFromContainer](https://github.com/ssmiller25/sinker/blob/main/internal/manifest/kubernetes.go#L226-L257)