### PR TITLE
Fix image generation when Envoy/Istio logging tags included

### DIFF
--- a/internal/manifest/kubernetes.go
+++ b/internal/manifest/kubernetes.go
@@ -267,7 +267,7 @@ func getImagesFromContainers(containers []corev1.Container) []string {
 				}
 			}
 
-			if skiploop == true {
+			if skiploop {
 				continue
 			}
 

--- a/internal/manifest/kubernetes_test.go
+++ b/internal/manifest/kubernetes_test.go
@@ -54,3 +54,30 @@ func TestGetImagesFromContainers_WithURLParameter(t *testing.T) {
 	}
 
 }
+
+// Envoy/Istio specify their log levels as component:level (See https://www.envoyproxy.io/docs/envoy/latest/start/quick-start/run-envoy.html#debugging-envoy)
+func TestGetImagesFromContainers_WithLogComponent(t *testing.T) {
+	containers := []corev1.Container{
+		{
+			Image: "baseimage:v1",
+			Args: []string{
+				"--proxyComponentLogLevel=misc:error",
+				"--log_output_level=default:info",
+			},
+		},
+	}
+	actual := getImagesFromContainers(containers)
+
+	if !contains(actual, "baseimage:v1") {
+		t.Errorf("expected baseimage:v1 to exist in list of images but it did not: %v", actual)
+	}
+
+	if contains(actual, "misc:error") {
+		t.Errorf("Invalid image parsing for args contain misc:error parameter: %v", actual)
+	}
+
+	if contains(actual, "default:info") {
+		t.Errorf("Invalid image parsing for args contain default:info parameter: %v", actual)
+	}
+
+}


### PR DESCRIPTION
Addresses #44   A bit of refactoring for filtering out incorrect images as well.