### PR TITLE
Add version command showing current sinker version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: build
 build:
-	@go build
+	@go build -ldflags="-X 'github.com/plexsystems/sinker/internal/commands.sinkerVersion=$$(git describe --tags --always --dirty)'"
 
-.PHONY: test
+.PHONY: test 
 test:
 	@go test -v ./... -count=1
 

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -34,6 +34,7 @@ func NewDefaultCommand() *cobra.Command {
 	cmd.AddCommand(newPullCommand())
 	cmd.AddCommand(newPushCommand())
 	cmd.AddCommand(newCheckCommand())
+	cmd.AddCommand(newVersionCommand())
 
 	return &cmd
 }

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newVersionCommand() *cobra.Command {
+	cmd := cobra.Command{
+		Use:       "version",
+		Short:     "The version of sinker",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runVersionCommand(); err != nil {
+				return fmt.Errorf("list: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("output", "o", "", "Output the images in the manifest to a file")
+
+	return &cmd
+}
+
+func runVersionCommand() error {
+	fmt.Println("sinker version " + sinkerVersion)
+	return nil
+}


### PR DESCRIPTION
With `sinker version` it's easy to see if you're using the latest version.